### PR TITLE
FIX - Card title issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-experience-platform",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/CourseCard.vue
+++ b/src/components/CourseCard.vue
@@ -79,14 +79,14 @@ export default {
   name: "CourseCard",
   props: {
     course: Object,
-    index: String
+    index: String,
+    showChar: Number
   },
   methods: {
     cardTitle(title) {
-      let cTitle = "",
-        showChar = 67;
-      if (title.length > showChar) {
-        let c = title.substr(0, showChar);
+      let cTitle = "";
+      if (title.length > this.showChar) {
+        let c = title.substr(0, this.showChar);
         cTitle = c + '<span class="moreellipses">...&nbsp;</span>';
       } else cTitle = title;
       return cTitle;
@@ -161,8 +161,8 @@ export default {
         line-height: 30px;
         letter-spacing: 0.15px;
         color: rgba(0, 0, 0, 0.87);
-        overflow: hidden;
-        height: calc(100% - 15px);
+        // overflow: hidden;
+        // height: calc(100% - 15px);
       }
       .card__reviews {
         font-size: 12px;

--- a/src/components/CourseCard.vue
+++ b/src/components/CourseCard.vue
@@ -6,10 +6,14 @@
           <b-card-body class="h-100">
             <div class="courses-card__sec1">
               <b-row class="h-100">
-                <b-col md="8" class="courses-card__left">
-                  <div>
+                <b-col md="8" class="courses-card__left h-100">
+                  <div class="h-100">
                     <p class="card-label">Category</p>
-                    <b-card-title>{{ course.title }}</b-card-title>
+                    <h4
+                      class="card-title"
+                      :title="course.title"
+                      v-html="cardTitle(course.title)"
+                    ></h4>
                   </div>
                 </b-col>
                 <b-col md="4" class="courses-card__right">
@@ -76,6 +80,17 @@ export default {
   props: {
     course: Object,
     index: String
+  },
+  methods: {
+    cardTitle(title) {
+      let cTitle = "",
+        showChar = 67;
+      if (title.length > showChar) {
+        let c = title.substr(0, showChar);
+        cTitle = c + '<span class="moreellipses">...&nbsp;</span>';
+      } else cTitle = title;
+      return cTitle;
+    }
   }
 };
 </script>
@@ -146,6 +161,8 @@ export default {
         line-height: 30px;
         letter-spacing: 0.15px;
         color: rgba(0, 0, 0, 0.87);
+        overflow: hidden;
+        height: calc(100% - 15px);
       }
       .card__reviews {
         font-size: 12px;

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -269,6 +269,9 @@ export default {
       .course-card {
         .card {
           height: 250px;
+          .card-title {
+            height: calc(100% - 10px);
+          }
         }
       }
     }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -95,6 +95,7 @@
                         :course="c"
                         :index="`course-card-${index}`"
                         @click="onCard(c)"
+                        :showChar="60"
                       ></CourseCard>
                     </div>
                   </b-tab>
@@ -156,11 +157,10 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      this.$store.dispatch("getAllCourses");
+      this.$store.dispatch("getAllCourses").then(() => {
+        this.initiateSlider(".slider-0");
+      });
     });
-    setTimeout(() => {
-      this.initiateSlider(".slider-0");
-    }, 500);
   },
   computed: {
     ...mapGetters(["allCourses", "allAuth"])
@@ -269,9 +269,9 @@ export default {
       .course-card {
         .card {
           height: 250px;
-          .card-title {
-            height: calc(100% - 10px);
-          }
+          // .card-title {
+          //   height: calc(100% - 10px);
+          // }
         }
       }
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -48,6 +48,7 @@
                         :key="index"
                         :course="c"
                         :index="`course-card-${index}`"
+                        :showChar="65"
                       ></CourseCard>
                     </div>
                   </b-tab>
@@ -197,11 +198,10 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      this.$store.dispatch("getAllCourses");
+      this.$store.dispatch("getAllCourses").then(() => {
+        this.initiateSlider(".slider-0");
+      });
     });
-    setTimeout(() => {
-      this.initiateSlider(".slider-0");
-    }, 500);
   },
   methods: {
     initiateSlider(container) {


### PR DESCRIPTION
@gkmahendran09  Fixed the card title overlap issue by adding ellipsis in both home and dashboard page
<img width="1402" alt="home-card" src="https://user-images.githubusercontent.com/34397979/92126811-427ae000-ee1e-11ea-9d0d-5739913bb950.png">

<img width="1100" alt="dashboard-card" src="https://user-images.githubusercontent.com/34397979/92126797-3ee75900-ee1e-11ea-90d0-646e2d6acd84.png">
